### PR TITLE
Fix EasyMic release workflows

### DIFF
--- a/.github/workflows/unity.yml
+++ b/.github/workflows/unity.yml
@@ -68,29 +68,32 @@ jobs:
             build-target: StandaloneOSX
     steps:
       - uses: actions/checkout@v4
-      - uses: RageAgainstThePixel/unity-setup@v1
+      - uses: RageAgainstThePixel/unity-setup@v2.6.0
         with:
           unity-version: ${{ matrix.unity-version }}
           build-targets: ${{ matrix.build-target }}
-      - uses: RageAgainstThePixel/activate-unity-license@v1
+          auto-update-hub: false
+      - uses: RageAgainstThePixel/activate-unity-license@v2.2.2
         with:
-          license: 'Personal'
+          license: 'personal'
           username: ${{ secrets.UNITY_USERNAME }}
           password: ${{ secrets.UNITY_PASSWORD }}
-      - uses: RageAgainstThePixel/unity-action@v1
+      - uses: RageAgainstThePixel/unity-action@v3.1.0
         name: '${{ matrix.build-target }}-Validate'
         with:
           build-target: ${{ matrix.build-target }}
           log-name: '${{ matrix.build-target }}-Validate'
           args: '-quit -nographics -batchmode -executeMethod Utilities.Editor.BuildPipeline.UnityPlayerBuildTools.ValidateProject -importTMProEssentialsAsset'
-      - uses: RageAgainstThePixel/unity-action@v1
-        name: '${{ matrix.build-target }}-Build'
+      - uses: RageAgainstThePixel/unity-action@v3.1.0
+        name: '${{ matrix.build-target }}-EditModeTests'
         with:
           build-target: ${{ matrix.build-target }}
-          log-name: '${{ matrix.build-target }}-Build'
-          args: '-quit -nographics -batchmode -executeMethod Utilities.Editor.BuildPipeline.UnityPlayerBuildTools.StartCommandLineBuild'
+          log-name: '${{ matrix.build-target }}-EditModeTests'
+          args: '-quit -nographics -batchmode -runTests -testPlatform EditMode -testResults "${{ github.workspace }}/EasyMic/TestResults-${{ matrix.build-target }}.xml"'
       - uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: '${{ github.run_number }}.${{ github.run_attempt }}-${{ matrix.os }}-${{ matrix.unity-version }}-${{ matrix.build-target }}-Artifacts'
-          path: '${{ github.workspace }}/**/*.log'
+          path: |
+            ${{ github.workspace }}/**/*.log
+            ${{ github.workspace }}/EasyMic/TestResults-${{ matrix.build-target }}.xml

--- a/.github/workflows/upm-subtree-split.yml
+++ b/.github/workflows/upm-subtree-split.yml
@@ -26,3 +26,5 @@ jobs:
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
       - uses: RageAgainstThePixel/upm-subtree-split@v1
+        with:
+          package-root: EasyMic/Packages/com.eitan.easymic

--- a/EasyMic/Packages/com.eitan.easymic/Editor/Integrations/Sherpa/SherpaAsrEditorControls.cs
+++ b/EasyMic/Packages/com.eitan.easymic/Editor/Integrations/Sherpa/SherpaAsrEditorControls.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Eitan.EasyMic.Editor.Icons;
 using UnityEditor;
 using UnityEngine;
@@ -714,7 +715,7 @@ namespace Eitan.EasyMic.Editor.Integration.SherpaONNXUnity
         private static string GetManualFieldKey(SerializedProperty property)
         {
             int targetId = property.serializedObject.targetObject != null
-                ? property.serializedObject.targetObject.GetInstanceID()
+                ? RuntimeHelpers.GetHashCode(property.serializedObject.targetObject)
                 : 0;
             return targetId.ToString() + ":" + property.propertyPath;
         }

--- a/EasyMic/Packages/com.eitan.easymic/Runtime/Integrations/SherpaONNXUnity/Integrations/Input/EasyMicSherpaAudioInputSource.cs
+++ b/EasyMic/Packages/com.eitan.easymic/Runtime/Integrations/SherpaONNXUnity/Integrations/Input/EasyMicSherpaAudioInputSource.cs
@@ -1,6 +1,7 @@
 #if EITAN_SHERPA_ONNX_UNITY_PRESENT
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Eitan.EasyMic;
 using Eitan.EasyMic.Runtime;
@@ -374,7 +375,7 @@ namespace Eitan.EasyMic.Runtime.Integration.SherpaONNXUnity.Integrations.Input
         {
             int targetSampleRate = OutputSampleRate;
             int chunkFrames = CalculateChunkFrames(targetSampleRate, chunkDurationSeconds);
-            string key = $"{nameof(EasyMicSherpaAudioInputSource)}:{GetInstanceID()}:{generation}:{targetSampleRate}:{chunkFrames}";
+            string key = $"{nameof(EasyMicSherpaAudioInputSource)}:{RuntimeHelpers.GetHashCode(this)}:{generation}:{targetSampleRate}:{chunkFrames}";
 
             return new[]
             {

--- a/EasyMic/Packages/com.eitan.easymic/Runtime/Unity/Components/Microphone/EasyMicrophone.cs
+++ b/EasyMic/Packages/com.eitan.easymic/Runtime/Unity/Components/Microphone/EasyMicrophone.cs
@@ -5,6 +5,7 @@ namespace Eitan.EasyMic.Runtime.Mono
     using System.Collections;
     using System.IO;
     using System.Linq;
+    using System.Runtime.CompilerServices;
     using Eitan.EasyMic.Runtime;
     using Eitan.EasyMic.Runtime.Exceptions;
     using Eitan.EasyMic.Runtime.Mono.Recording;
@@ -660,7 +661,7 @@ namespace Eitan.EasyMic.Runtime.Mono
             _streamingWriter?.Dispose();
             _streamingWriter = null;
 
-            _activeTempFilePath = RecordingPathUtility.PrepareActiveTempRecordingPath(GetInstanceID());
+            _activeTempFilePath = RecordingPathUtility.PrepareActiveTempRecordingPath(RuntimeHelpers.GetHashCode(this));
             _latestRecordingTempPath = null;
 
             var deviceName = string.IsNullOrEmpty(_deviceOptions.DeviceName) ? null : _deviceOptions.DeviceName;


### PR DESCRIPTION
## Summary
- pin the UPM subtree split to `EasyMic/Packages/com.eitan.easymic` so only the public EasyMic package is published
- remove the tracked Unity Services project settings package marker that caused extra package detection
- update Unity CI actions, disable Hub auto-update, and replace package-repo Player Build with EditMode test validation
- avoid Unity 6000 `GetInstanceID()` obsolete warnings in EasyMic code paths

## Verification
- `actionlint .github/workflows/*.yml`
- YAML parse check for `.github/workflows/*.yml`
- `git diff --check`
- `dotnet build EasyMic/Eitan.EasyMic.Mono.csproj`
- `dotnet build EasyMic/Eitan.EasyMic.Editor.Mono.csproj`
- `git ls-files "EasyMic/**/package.json" "EasyMic/ProjectSettings/Packages/**" "EasyMic/Packages/com.eitan.easymic.apm/**" "EasyMic/Packages/packages-lock.json" ".github/.DS_Store"` returns only `EasyMic/Packages/com.eitan.easymic/package.json`

## Note
`dotnet build EasyMic/Eitan.EasyMic.Integration.SherpaONNXUnity.csproj` still requires optional local integration assemblies and is not part of this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Unity CI workflow with newer GitHub Actions versions and added project validation and EditMode testing steps
  * Adjusted artifact uploading to capture log files and test results
  * Updated UPM subtree split workflow configuration

* **Refactor**
  * Modified identifier generation in audio input and microphone components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->